### PR TITLE
Kills the process on more OAuth failures

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -193,9 +193,7 @@ export default async function startServer({ opbeat }: ServerArgs) {
     // processing.
     .subscribe({
       error: err => {
-        console.log(
-          '----- PROCESSING PIPELINE ERRORED. THAT SHOULDN’T HAPPEN -----'
-        );
+        console.log('----- PROCESSING PIPELINE VERY FATAL ERROR -----');
         opbeat.captureError(err);
         process.kill(process.pid, 'SIGHUP');
       },

--- a/server/stages/load-cases.js
+++ b/server/stages/load-cases.js
@@ -47,8 +47,9 @@ const hydrateIdBatch = (idBatch: CaseIdBatch) => (
 // active at any time. Open311 API failures are retried with an exponential
 // backoff before failing.
 //
-// This op catches and logs / reports all errors so that the source observable
-// isn't terminated.
+// This op catches and logs / reports most errors so that the source observable
+// isn't terminated. The exception is Salesforce session auth exceptions, which
+// we propagate up to terminate the job.
 export default ({ open311, opbeat }: Deps) => (
   batch$: Rx.Observable<CaseIdBatch>
 ): Rx.Observable<LoadedCaseBatch> =>
@@ -71,10 +72,23 @@ export default ({ open311, opbeat }: Deps) => (
       {
         length: length => logQueueLength('load-cases', length),
         error: (err, batch) => {
-          opbeat.captureError(err);
-          logMessage('load-cases', 'Permanent failure loading cases', {
-            batch,
-          });
+          // If we get this error message from Salesforce, it means that our
+          // OAuth token has expired and we need to restart to fetch it.
+          //
+          // Throwing out of this stage will fail back up to the server
+          // pipeline.
+          if (err.message === 'Session expired or invalid') {
+            logMessage('load-cases', 'Salesforce auth error loading cases', {
+              batch,
+            });
+
+            throw err;
+          } else {
+            opbeat.captureError(err);
+            logMessage('load-cases', 'Permanent failure loading cases', {
+              batch,
+            });
+          }
         },
       }
     )


### PR DESCRIPTION
The event stream can still be alive even if the OAuth token to the
Open311 API is failing. We trickle that error up to cause a process
restart.